### PR TITLE
 Remove fatal logging when config not found

### DIFF
--- a/app-migrator.yml.example
+++ b/app-migrator.yml.example
@@ -1,0 +1,21 @@
+export_dir: "export"
+exclude_orgs:
+  - system
+max_parallel: 5
+non_interactive: true
+domains_to_add:
+  - new.domain
+domains_to_replace:
+  old.domain: new.domain
+source_api:
+  url: https://api.sys1.cf.example.com
+  username: admin
+  password: some-password
+  client_id:
+  client_secret:
+target_api:
+  url: https://api.sys2.cf.example.com
+  username: admin
+  password: some-password
+  client_id:
+  client_secret:

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -176,8 +176,6 @@ func (c *Config) initViperConfig() {
 	if err := v.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			log.Fatalf("Failed to load config file: %s, error: %s", v.ConfigFileUsed(), err)
-		} else {
-			log.Fatalf("%v", err)
 		}
 	}
 	c.applyViperOverrides(v)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -60,7 +60,7 @@ func CreateRootCommand(ctx *context.Context) *cobra.Command {
 
 	// show a migration summary for all commands
 	rootCmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
-		if cmd.Name() == "help" {
+		if cmd.Name() == "help" || cmd.Name() == "completion" {
 			return
 		}
 		err := cli.PostRunSaveMetadata(ctx)


### PR DESCRIPTION
Since `app-migrator.yml` is not required, we no longer log an error message when app-migrator.yml is not found. This was causing the panic. We also do not print out the report summary when the `completion` command is run.